### PR TITLE
Fix build on 4.x kernels (and hopefully 5.x as well, 5.x not tested)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/LightPcapNg"]
+	path = src/LightPcapNg
+	url = https://github.com/rvelea/LightPcapNg.git

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # cangaroo
 open source can bus analyzer
 
-written by Hubert Denkmair <hubert@denkmair.de>
+written by Hubert Denkmair <hubert@denkmair.de> (https://github.com/HubertD/cangaroo)
+
+Raw CAN tx support added by Ethan Zonca (https://github.com/normaldotcom/cangaroo)
+
+Pcanng file support added by Skip Hansen (https://github.com/skiphansen/cangaroo)
 
 ## building on linux
 * to install all required packages in a vanilla ubuntu 16.04:
   * sudo apt-get install build-essential git qt5-qmake qtbase5-dev libnl-3-dev libnl-route-3-dev
 * build with:
+  * git submodule init;git submodule update
   * qmake -qt=qt5
   * make
   * make install
 
-## building on windows
+## building on windows 
 * Qt Creator (Community Version is okay) brings everything you need
 * except for the PCAN libraries. 
   * Get them from http://www.peak-system.com/fileadmin/media/files/pcan-basic.zip
@@ -23,6 +28,8 @@ written by Hubert Denkmair <hubert@denkmair.de>
   from src/src.pro
 * if you want to deploy the cangaroo app, make sure to also include the needed Qt Libraries.
   for a normal release build, these are: Qt5Core.dll Qt5Gui.dll Qt5Widgets.dll Qt5Xml.dll
+
+**NB: Building on Windows has not been tested on Skip Hansen's fork**
 
 ## changelog
 

--- a/build/moc/moc_predefs.h
+++ b/build/moc/moc_predefs.h
@@ -1,98 +1,130 @@
+#define __SSP_STRONG__ 3
 #define __DBL_MIN_EXP__ (-1021)
+#define __FLT32X_MAX_EXP__ 1024
 #define __cpp_attributes 200809
-#define __pentiumpro__ 1
 #define __UINT_LEAST16_MAX__ 0xffff
 #define __ATOMIC_ACQUIRE 2
-#define __FLT_MIN__ 1.17549435082228750797e-38F
+#define __FLT128_MAX_10_EXP__ 4932
+#define __FLT_MIN__ 1.17549435082228750796873653722224568e-38F
 #define __GCC_IEC_559_COMPLEX 2
 #define __UINT_LEAST8_TYPE__ unsigned char
-#define __SIZEOF_FLOAT80__ 12
-#define _WIN32 1
-#define __INTMAX_C(c) c ## LL
+#define __SIZEOF_FLOAT80__ 16
+#define __INTMAX_C(c) c ## L
 #define __CHAR_BIT__ 8
 #define __UINT8_MAX__ 0xff
-#define __WINT_MAX__ 0xffff
+#define __WINT_MAX__ 0xffffffffU
+#define __FLT32_MIN_EXP__ (-125)
 #define __cpp_static_assert 200410
 #define __ORDER_LITTLE_ENDIAN__ 1234
-#define __SIZE_MAX__ 0xffffffffU
-#define __WCHAR_MAX__ 0xffff
+#define __SIZE_MAX__ 0xffffffffffffffffUL
+#define __WCHAR_MAX__ 0x7fffffff
 #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
 #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
 #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
-#define __DBL_DENORM_MIN__ double(4.94065645841246544177e-324L)
+#define __DBL_DENORM_MIN__ double(4.94065645841246544176568792868221372e-324L)
 #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
 #define __GCC_ATOMIC_CHAR_LOCK_FREE 2
 #define __GCC_IEC_559 2
-#define __FLT_EVAL_METHOD__ 2
+#define __FLT32X_DECIMAL_DIG__ 17
+#define __FLT_EVAL_METHOD__ 0
+#define __unix__ 1
 #define __cpp_binary_literals 201304
+#define __FLT64_DECIMAL_DIG__ 17
 #define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __x86_64 1
 #define __cpp_variadic_templates 200704
-#define __UINT_FAST64_MAX__ 0xffffffffffffffffULL
+#define __UINT_FAST64_MAX__ 0xffffffffffffffffUL
 #define __SIG_ATOMIC_TYPE__ int
 #define __DBL_MIN_10_EXP__ (-307)
 #define __FINITE_MATH_ONLY__ 0
 #define __GNUC_PATCHLEVEL__ 0
+#define __FLT32_HAS_DENORM__ 1
 #define __UINT_FAST8_MAX__ 0xff
 #define __has_include(STR) __has_include__(STR)
-#define _stdcall __attribute__((__stdcall__))
 #define __DEC64_MAX_EXP__ 385
 #define __INT8_C(c) c
-#define __UINT_LEAST64_MAX__ 0xffffffffffffffffULL
+#define __INT_LEAST8_WIDTH__ 8
+#define __UINT_LEAST64_MAX__ 0xffffffffffffffffUL
 #define __SHRT_MAX__ 0x7fff
-#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MAX__ 1.18973149535723176502126385303097021e+4932L
+#define __FLT64X_MAX_10_EXP__ 4932
 #define __UINT_LEAST8_MAX__ 0xff
 #define __GCC_ATOMIC_BOOL_LOCK_FREE 2
-#define __UINTMAX_TYPE__ long long unsigned int
+#define __FLT128_DENORM_MIN__ 6.47517511943802511092443895822764655e-4966F128
+#define __UINTMAX_TYPE__ long unsigned int
+#define __linux 1
 #define __DEC32_EPSILON__ 1E-6DF
+#define __FLT_EVAL_METHOD_TS_18661_3__ 0
 #define __OPTIMIZE__ 1
+#define __unix 1
 #define __UINT32_MAX__ 0xffffffffU
 #define __GXX_EXPERIMENTAL_CXX0X__ 1
 #define __LDBL_MAX_EXP__ 16384
-#define __WINT_MIN__ 0
+#define __FLT128_MIN_EXP__ (-16381)
+#define __WINT_MIN__ 0U
+#define __linux__ 1
+#define __FLT128_MIN_10_EXP__ (-4931)
+#define __INT_LEAST16_WIDTH__ 16
 #define __SCHAR_MAX__ 0x7f
-#define __WCHAR_MIN__ 0
-#define __INT64_C(c) c ## LL
+#define __FLT128_MANT_DIG__ 113
+#define __WCHAR_MIN__ (-__WCHAR_MAX__ - 1)
+#define __INT64_C(c) c ## L
 #define __DBL_DIG__ 15
 #define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __FLT64X_MANT_DIG__ 64
+#define _FORTIFY_SOURCE 2
 #define __SIZEOF_INT__ 4
-#define __SIZEOF_POINTER__ 4
+#define __SIZEOF_POINTER__ 8
 #define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
-#define __USER_LABEL_PREFIX__ _
+#define __USER_LABEL_PREFIX__ 
+#define __FLT64X_EPSILON__ 1.08420217248550443400745280086994171e-19F64x
 #define __STDC_HOSTED__ 1
-#define __WIN32 1
 #define __LDBL_HAS_INFINITY__ 1
-#define __FLT_EPSILON__ 1.19209289550781250000e-7F
+#define __FLT32_DIG__ 6
+#define __FLT_EPSILON__ 1.19209289550781250000000000000000000e-7F
 #define __GXX_WEAK__ 1
-#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __SHRT_WIDTH__ 16
+#define __LDBL_MIN__ 3.36210314311209350626267781732175260e-4932L
 #define __DEC32_MAX__ 9.999999E96DF
-#define __MINGW32__ 1
+#define __cpp_threadsafe_static_init 200806
+#define __FLT64X_DENORM_MIN__ 3.64519953188247460252840593361941982e-4951F64x
+#define __FLT32X_HAS_INFINITY__ 1
 #define __INT32_MAX__ 0x7fffffff
-#define __SIZEOF_LONG__ 4
+#define __INT_WIDTH__ 32
+#define __SIZEOF_LONG__ 8
+#define __STDC_IEC_559__ 1
+#define __STDC_ISO_10646__ 201706L
 #define __UINT16_C(c) c
+#define __PTRDIFF_WIDTH__ 64
 #define __DECIMAL_DIG__ 21
+#define __FLT64_EPSILON__ 2.22044604925031308084726333618164062e-16F64
+#define __gnu_linux__ 1
+#define __INTMAX_WIDTH__ 64
+#define __FLT64_MIN_EXP__ (-1021)
 #define __has_include_next(STR) __has_include_next__(STR)
+#define __FLT64X_MIN_10_EXP__ (-4931)
 #define __LDBL_HAS_QUIET_NAN__ 1
-#define _REENTRANT 1
-#define __GNUC__ 5
-#define _cdecl __attribute__((__cdecl__))
+#define __FLT64_MANT_DIG__ 53
+#define __GNUC__ 7
 #define __GXX_RTTI 1
+#define __pie__ 2
+#define __MMX__ 1
 #define __cpp_delegating_constructors 200604
 #define __FLT_HAS_DENORM__ 1
-#define __SIZEOF_LONG_DOUBLE__ 12
+#define __SIZEOF_LONG_DOUBLE__ 16
 #define __BIGGEST_ALIGNMENT__ 16
 #define __STDC_UTF_16__ 1
-#define __i686 1
-#define __DBL_MAX__ double(1.79769313486231570815e+308L)
-#define _thiscall __attribute__((__thiscall__))
+#define __FLT64_MAX_10_EXP__ 308
+#define __FLT32_HAS_INFINITY__ 1
+#define __DBL_MAX__ double(1.79769313486231570814527423731704357e+308L)
 #define __cpp_raw_strings 200710
-#define __INT_FAST32_MAX__ 0x7fffffff
-#define __WINNT 1
+#define __INT_FAST32_MAX__ 0x7fffffffffffffffL
 #define __DBL_HAS_INFINITY__ 1
-#define __INT64_MAX__ 0x7fffffffffffffffLL
-#define __WINNT__ 1
+#define __INT64_MAX__ 0x7fffffffffffffffL
 #define __DEC32_MIN_EXP__ (-94)
-#define __INT_FAST16_TYPE__ short int
-#define _fastcall __attribute__((__fastcall__))
+#define __INTPTR_WIDTH__ 64
+#define __FLT32X_HAS_DENORM__ 1
+#define __INT_FAST16_TYPE__ long int
 #define __LDBL_HAS_DENORM__ 1
 #define __cplusplus 201103L
 #define __cpp_ref_qualifiers 200710
@@ -100,179 +132,251 @@
 #define __INT_LEAST32_MAX__ 0x7fffffff
 #define __DEC32_MIN__ 1E-95DF
 #define __DEPRECATED 1
+#define __cpp_rvalue_references 200610
 #define __DBL_MAX_EXP__ 1024
+#define __WCHAR_WIDTH__ 32
+#define __FLT32_MAX__ 3.40282346638528859811704183484516925e+38F32
 #define __DEC128_EPSILON__ 1E-33DL
+#define __SSE2_MATH__ 1
 #define __ATOMIC_HLE_RELEASE 131072
-#define __WIN32__ 1
-#define __PTRDIFF_MAX__ 0x7fffffff
+#define __PTRDIFF_MAX__ 0x7fffffffffffffffL
+#define __amd64 1
+#define __STDC_NO_THREADS__ 1
 #define __ATOMIC_HLE_ACQUIRE 65536
-#define __GNUG__ 5
+#define __FLT32_HAS_QUIET_NAN__ 1
+#define __GNUG__ 7
 #define __LONG_LONG_MAX__ 0x7fffffffffffffffLL
-#define __SIZEOF_SIZE_T__ 4
+#define __SIZEOF_SIZE_T__ 8
 #define __cpp_rvalue_reference 200610
 #define __cpp_nsdmi 200809
-#define __SIZEOF_WINT_T__ 2
+#define __FLT64X_MIN_EXP__ (-16381)
+#define __SIZEOF_WINT_T__ 4
+#define __LONG_LONG_WIDTH__ 64
 #define __cpp_initializer_lists 200806
+#define __FLT32_MAX_EXP__ 128
+#define __cpp_hex_float 201603
 #define __GCC_HAVE_DWARF2_CFI_ASM 1
-#define __GXX_ABI_VERSION 1009
+#define __GXX_ABI_VERSION 1011
+#define __FLT128_HAS_INFINITY__ 1
 #define __FLT_MIN_EXP__ (-125)
-#define __i686__ 1
 #define __cpp_lambdas 200907
-#define __INT_FAST64_TYPE__ long long int
-#define __DBL_MIN__ double(2.22507385850720138309e-308L)
-#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT64X_HAS_QUIET_NAN__ 1
+#define __INT_FAST64_TYPE__ long int
+#define __FLT64_DENORM_MIN__ 4.94065645841246544176568792868221372e-324F64
+#define __DBL_MIN__ double(2.22507385850720138309023271733240406e-308L)
+#define __PIE__ 2
+#define __LP64__ 1
+#define __FLT32X_EPSILON__ 2.22044604925031308084726333618164062e-16F32x
 #define __DECIMAL_BID_FORMAT__ 1
-#define __GXX_TYPEINFO_EQUALITY_INLINE 0
+#define __FLT64_MIN_10_EXP__ (-307)
+#define __FLT64X_DECIMAL_DIG__ 21
 #define __DEC128_MIN__ 1E-6143DL
 #define __REGISTER_PREFIX__ 
 #define __UINT16_MAX__ 0xffff
 #define __DBL_HAS_DENORM__ 1
-#define __cdecl __attribute__((__cdecl__))
+#define __FLT32_MIN__ 1.17549435082228750796873653722224568e-38F32
 #define __UINT8_TYPE__ unsigned char
-#define __i386 1
 #define __FLT_MANT_DIG__ 24
-#define __VERSION__ "5.3.0"
-#define __UINT64_C(c) c ## ULL
+#define __LDBL_DECIMAL_DIG__ 21
+#define __VERSION__ "7.5.0"
+#define __UINT64_C(c) c ## UL
 #define __cpp_unicode_characters 200704
+#define _STDC_PREDEF_H 1
 #define __GCC_ATOMIC_INT_LOCK_FREE 2
-#define _X86_ 1
+#define __FLT128_MAX_EXP__ 16384
+#define __FLT32_MANT_DIG__ 24
 #define __FLOAT_WORD_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __STDC_IEC_559_COMPLEX__ 1
+#define __FLT128_HAS_DENORM__ 1
+#define __FLT128_DIG__ 33
+#define __SCHAR_WIDTH__ 8
 #define __INT32_C(c) c
 #define __DEC64_EPSILON__ 1E-15DD
 #define __ORDER_PDP_ENDIAN__ 3412
 #define __DEC128_MIN_EXP__ (-6142)
-#define __code_model_32__ 1
-#define __INT_FAST32_TYPE__ int
+#define __FLT32_MAX_10_EXP__ 38
+#define __INT_FAST32_TYPE__ long int
 #define __UINT_LEAST16_TYPE__ short unsigned int
+#define __FLT64X_HAS_INFINITY__ 1
+#define unix 1
 #define __INT16_MAX__ 0x7fff
-#define __i386__ 1
 #define __cpp_rtti 199711
-#define __SIZE_TYPE__ unsigned int
-#define __UINT64_MAX__ 0xffffffffffffffffULL
+#define __SIZE_TYPE__ long unsigned int
+#define __UINT64_MAX__ 0xffffffffffffffffUL
+#define __FLT64X_DIG__ 18
 #define __INT8_TYPE__ signed char
+#define __ELF__ 1
+#define __GCC_ASM_FLAG_OUTPUTS__ 1
 #define __FLT_RADIX__ 2
 #define __INT_LEAST16_TYPE__ short int
-#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
-#define __UINTMAX_C(c) c ## ULL
+#define __LDBL_EPSILON__ 1.08420217248550443400745280086994171e-19L
+#define __UINTMAX_C(c) c ## UL
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __k8 1
 #define __SIG_ATOMIC_MAX__ 0x7fffffff
 #define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
-#define __SIZEOF_PTRDIFF_T__ 4
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __FLT32X_MANT_DIG__ 53
+#define __x86_64__ 1
+#define __FLT32X_MIN_EXP__ (-1021)
 #define __DEC32_SUBNORMAL_MIN__ 0.000001E-95DF
-#define __pentiumpro 1
-#define __MSVCRT__ 1
-#define __INT_FAST16_MAX__ 0x7fff
-#define __UINT_FAST32_MAX__ 0xffffffffU
-#define __UINT_LEAST64_TYPE__ long long unsigned int
+#define __INT_FAST16_MAX__ 0x7fffffffffffffffL
+#define __FLT64_DIG__ 15
+#define __UINT_FAST32_MAX__ 0xffffffffffffffffUL
+#define __UINT_LEAST64_TYPE__ long unsigned int
 #define __FLT_HAS_QUIET_NAN__ 1
 #define __FLT_MAX_10_EXP__ 38
-#define __LONG_MAX__ 0x7fffffffL
+#define __LONG_MAX__ 0x7fffffffffffffffL
+#define __FLT64X_HAS_DENORM__ 1
 #define __DEC128_SUBNORMAL_MIN__ 0.000000000000000000000000000000001E-6143DL
 #define __FLT_HAS_INFINITY__ 1
 #define __cpp_unicode_literals 200710
-#define __UINT_FAST16_TYPE__ short unsigned int
+#define __UINT_FAST16_TYPE__ long unsigned int
 #define __DEC64_MAX__ 9.999999999999999E384DD
+#define __INT_FAST32_WIDTH__ 64
 #define __CHAR16_TYPE__ short unsigned int
 #define __PRAGMA_REDEFINE_EXTNAME 1
+#define __SIZE_WIDTH__ 64
+#define __SEG_FS 1
 #define __INT_LEAST16_MAX__ 0x7fff
 #define __DEC64_MANT_DIG__ 16
 #define __UINT_LEAST32_MAX__ 0xffffffffU
+#define __SEG_GS 1
+#define __FLT32_DENORM_MIN__ 1.40129846432481707092372958328991613e-45F32
 #define __GCC_ATOMIC_LONG_LOCK_FREE 2
-#define __INT_LEAST64_TYPE__ long long int
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __INT_LEAST64_TYPE__ long int
 #define __INT16_TYPE__ short int
 #define __INT_LEAST8_TYPE__ signed char
 #define __DEC32_MAX_EXP__ 97
 #define __INT_FAST8_MAX__ 0x7f
-#define __INTPTR_MAX__ 0x7fffffff
-#define __GXX_MERGED_TYPEINFO_NAMES 0
+#define __FLT128_MAX__ 1.18973149535723176508575932662800702e+4932F128
+#define __INTPTR_MAX__ 0x7fffffffffffffffL
+#define linux 1
 #define __cpp_range_based_for 200907
-#define __stdcall __attribute__((__stdcall__))
+#define __FLT64_HAS_QUIET_NAN__ 1
+#define __FLT32_MIN_10_EXP__ (-37)
+#define __SSE2__ 1
 #define __EXCEPTIONS 1
 #define __LDBL_MANT_DIG__ 64
 #define __DBL_HAS_QUIET_NAN__ 1
+#define __FLT64_HAS_INFINITY__ 1
+#define __FLT64X_MAX__ 1.18973149535723176502126385303097021e+4932F64x
 #define __SIG_ATOMIC_MIN__ (-__SIG_ATOMIC_MAX__ - 1)
-#define __INTPTR_TYPE__ int
+#define __code_model_small__ 1
+#define __k8__ 1
+#define __INTPTR_TYPE__ long int
 #define __UINT16_TYPE__ short unsigned int
-#define __WCHAR_TYPE__ short unsigned int
+#define __WCHAR_TYPE__ int
 #define __SIZEOF_FLOAT__ 4
-#define __UINTPTR_MAX__ 0xffffffffU
+#define __pic__ 2
+#define __UINTPTR_MAX__ 0xffffffffffffffffUL
+#define __INT_FAST64_WIDTH__ 64
 #define __DEC64_MIN_EXP__ (-382)
 #define __cpp_decltype 200707
-#define __INT_FAST64_MAX__ 0x7fffffffffffffffLL
+#define __FLT32_DECIMAL_DIG__ 9
+#define __INT_FAST64_MAX__ 0x7fffffffffffffffL
 #define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
 #define __FLT_DIG__ 6
-#define __UINT_FAST64_TYPE__ long long unsigned int
+#define __FLT64X_MAX_EXP__ 16384
+#define __UINT_FAST64_TYPE__ long unsigned int
 #define __INT_MAX__ 0x7fffffff
-#define WIN32 1
-#define __INT64_TYPE__ long long int
+#define __amd64__ 1
+#define __INT64_TYPE__ long int
 #define __FLT_MAX_EXP__ 128
+#define __ORDER_BIG_ENDIAN__ 4321
 #define __DBL_MANT_DIG__ 53
-#define __cpp_inheriting_constructors 200802
+#define __cpp_inheriting_constructors 201511
 #define __SIZEOF_FLOAT128__ 16
-#define __INT_LEAST64_MAX__ 0x7fffffffffffffffLL
+#define __INT_LEAST64_MAX__ 0x7fffffffffffffffL
 #define __DEC64_MIN__ 1E-383DD
-#define __WINT_TYPE__ short unsigned int
+#define __WINT_TYPE__ unsigned int
 #define __UINT_LEAST32_TYPE__ unsigned int
 #define __SIZEOF_SHORT__ 2
+#define __SSE__ 1
 #define __LDBL_MIN_EXP__ (-16381)
+#define __FLT64_MAX__ 1.79769313486231570814527423731704357e+308F64
+#define __WINT_WIDTH__ 32
 #define __INT_LEAST8_MAX__ 0x7f
-#define __WCHAR_UNSIGNED__ 1
+#define __FLT32X_MAX_10_EXP__ 308
+#define __SIZEOF_INT128__ 16
 #define __LDBL_MAX_10_EXP__ 4932
 #define __ATOMIC_RELAXED 0
-#define __DBL_EPSILON__ double(2.22044604925031308085e-16L)
-#define __thiscall __attribute__((__thiscall__))
+#define __DBL_EPSILON__ double(2.22044604925031308084726333618164062e-16L)
+#define __FLT128_MIN__ 3.36210314311209350626267781732175260e-4932F128
+#define _LP64 1
 #define __UINT8_C(c) c
+#define __FLT64_MAX_EXP__ 1024
 #define __INT_LEAST32_TYPE__ int
-#define __SIZEOF_WCHAR_T__ 2
-#define __UINT64_TYPE__ long long unsigned int
+#define __SIZEOF_WCHAR_T__ 4
+#define __FLT128_HAS_QUIET_NAN__ 1
 #define __INT_FAST8_TYPE__ signed char
-#define __fastcall __attribute__((__fastcall__))
+#define __FLT64X_MIN__ 3.36210314311209350626267781732175260e-4932F64x
 #define __GNUC_STDC_INLINE__ 1
+#define __FLT64_HAS_DENORM__ 1
+#define __FLT32_EPSILON__ 1.19209289550781250000000000000000000e-7F32
 #define __DBL_DECIMAL_DIG__ 17
 #define __STDC_UTF_32__ 1
+#define __INT_FAST8_WIDTH__ 8
+#define __FXSR__ 1
 #define __DEC_EVAL_METHOD__ 2
-#define __ORDER_BIG_ENDIAN__ 4321
+#define __FLT32X_MAX__ 1.79769313486231570814527423731704357e+308F32x
 #define __cpp_runtime_arrays 198712
+#define __UINT64_TYPE__ long unsigned int
 #define __UINT32_C(c) c ## U
-#define __INTMAX_MAX__ 0x7fffffffffffffffLL
+#define __INTMAX_MAX__ 0x7fffffffffffffffL
 #define __cpp_alias_templates 200704
 #define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
-#define WINNT 1
-#define __FLT_DENORM_MIN__ 1.40129846432481707092e-45F
+#define __FLT_DENORM_MIN__ 1.40129846432481707092372958328991613e-45F
 #define __INT8_MAX__ 0x7f
-#define __UINT_FAST32_TYPE__ unsigned int
+#define __LONG_WIDTH__ 64
+#define __PIC__ 2
+#define __UINT_FAST32_TYPE__ long unsigned int
 #define __CHAR32_TYPE__ unsigned int
-#define __FLT_MAX__ 3.40282346638528859812e+38F
+#define __FLT_MAX__ 3.40282346638528859811704183484516925e+38F
 #define __cpp_constexpr 200704
 #define __INT32_TYPE__ int
 #define __SIZEOF_DOUBLE__ 8
 #define __cpp_exceptions 199711
-#define __INTMAX_TYPE__ long long int
-#define i386 1
-#define _INTEGRAL_MAX_BITS 64
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT64_MIN__ 2.22507385850720138309023271733240406e-308F64
+#define __INT_LEAST32_WIDTH__ 32
+#define __INTMAX_TYPE__ long int
 #define __DEC128_MAX_EXP__ 6145
+#define __FLT32X_HAS_QUIET_NAN__ 1
 #define __ATOMIC_CONSUME 1
-#define __GNUC_MINOR__ 3
-#define __UINTMAX_MAX__ 0xffffffffffffffffULL
+#define __GNUC_MINOR__ 5
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __INT_FAST16_WIDTH__ 64
+#define __UINTMAX_MAX__ 0xffffffffffffffffUL
 #define __DEC32_MANT_DIG__ 7
+#define __FLT32X_DENORM_MIN__ 4.94065645841246544176568792868221372e-324F32x
 #define __DBL_MAX_10_EXP__ 308
-#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DENORM_MIN__ 3.64519953188247460252840593361941982e-4951L
 #define __INT16_C(c) c
 #define __STDC__ 1
-#define __PTRDIFF_TYPE__ int
+#define __FLT32X_DIG__ 15
+#define __PTRDIFF_TYPE__ long int
 #define __ATOMIC_SEQ_CST 5
 #define __UINT32_TYPE__ unsigned int
-#define __UINTPTR_TYPE__ unsigned int
+#define __FLT32X_MIN_10_EXP__ (-307)
+#define __UINTPTR_TYPE__ long unsigned int
 #define __DEC64_SUBNORMAL_MIN__ 0.000000000000001E-383DD
 #define __DEC128_MANT_DIG__ 34
 #define __LDBL_MIN_10_EXP__ (-4931)
+#define __FLT128_EPSILON__ 1.92592994438723585305597794258492732e-34F128
+#define __SSE_MATH__ 1
 #define __SIZEOF_LONG_LONG__ 8
 #define __cpp_user_defined_literals 200809
+#define __FLT128_DECIMAL_DIG__ 36
 #define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __FLT32X_MIN__ 2.22507385850720138309023271733240406e-308F32x
 #define __LDBL_DIG__ 18
 #define __FLT_DECIMAL_DIG__ 9
-#define __UINT_FAST16_MAX__ 0xffff
+#define __UINT_FAST16_MAX__ 0xffffffffffffffffUL
 #define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __INT_LEAST64_WIDTH__ 64
 #define __UINT_FAST8_TYPE__ unsigned char
+#define _GNU_SOURCE 1
 #define __ATOMIC_ACQ_REL 4
 #define __ATOMIC_RELEASE 3
-#define __declspec(x) __attribute__((x))

--- a/src/LightPcapNg.pri
+++ b/src/LightPcapNg.pri
@@ -1,0 +1,21 @@
+HEADERS += \
+    $$PWD/LightPcapNg/include/light_debug.h \
+    $$PWD/LightPcapNg/include/light_internal.h \
+    $$PWD/LightPcapNg/include/light_pcapng_ext.h \
+    $$PWD/LightPcapNg/include/light_pcapng.h \
+    $$PWD/LightPcapNg/include/light_platform.h \
+    $$PWD/LightPcapNg/include/light_special.h \
+    $$PWD/LightPcapNg/include/light_types.h \
+    $$PWD/LightPcapNg/include/light_util.h
+
+SOURCES += \
+    $$PWD/LightPcapNg/src/light_advanced.c \
+    $$PWD/LightPcapNg/src/light_alloc.c \
+    $$PWD/LightPcapNg/src/light_internal.c \
+    $$PWD/LightPcapNg/src/light_io.c \
+    $$PWD/LightPcapNg/src/light_manipulate.c \
+    $$PWD/LightPcapNg/src/light_option.c \
+    $$PWD/LightPcapNg/src/light_pcapng.c \
+    $$PWD/LightPcapNg/src/light_pcapng_cont.c \
+    $$PWD/LightPcapNg/src/light_pcapng_ext.c \
+    $$PWD/LightPcapNg/src/light_platform.c

--- a/src/driver/GenericCanSetupPage.ui
+++ b/src/driver/GenericCanSetupPage.ui
@@ -188,8 +188,8 @@
     <rect>
      <x>9</x>
      <y>220</y>
-     <width>41</width>
-     <height>16</height>
+     <width>59</width>
+     <height>17</height>
     </rect>
    </property>
    <property name="text">
@@ -202,7 +202,7 @@
      <x>140</x>
      <y>220</y>
      <width>411</width>
-     <height>126</height>
+     <height>141</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="vbOptions">

--- a/src/driver/SocketCanDriver/SocketCanInterface.cpp
+++ b/src/driver/SocketCanDriver/SocketCanInterface.cpp
@@ -55,8 +55,8 @@
 
 SocketCanInterface::SocketCanInterface(SocketCanDriver *driver, int index, QString name)
   : CanInterface((CanDriver *)driver),
-	_idx(index),
-	_fd(0),
+   _idx(index),
+   _fd(0),
     _name(name),
     _ts_mode(ts_mode_SIOCSHWTSTAMP)
 {
@@ -66,7 +66,7 @@ SocketCanInterface::~SocketCanInterface() {
 }
 
 QString SocketCanInterface::getName() const {
-	return _name;
+   return _name;
 }
 
 void SocketCanInterface::setName(QString name) {
@@ -356,53 +356,53 @@ const char *SocketCanInterface::cname()
 }
 
 void SocketCanInterface::open() {
-	if((_fd = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
-		perror("Error while opening socket");
-	}
+   if((_fd = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
+      perror("Error while opening socket");
+   }
 
-	struct ifreq ifr;
+   struct ifreq ifr;
     struct sockaddr_can addr;
     strcpy(ifr.ifr_name, _name.toStdString().c_str());
-	ioctl(_fd, SIOCGIFINDEX, &ifr);
+   ioctl(_fd, SIOCGIFINDEX, &ifr);
 
-	addr.can_family  = AF_CAN;
-	addr.can_ifindex = ifr.ifr_ifindex;
+   addr.can_family  = AF_CAN;
+   addr.can_ifindex = ifr.ifr_ifindex;
 
-	if(bind(_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-		perror("Error in socket bind");
-	}
+   if(bind(_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+      perror("Error in socket bind");
+   }
 }
 
 void SocketCanInterface::close() {
-	::close(_fd);
+   ::close(_fd);
 }
 
 void SocketCanInterface::sendMessage(const CanMessage &msg) {
-	struct can_frame frame;
+   struct can_frame frame;
 
-	frame.can_id = msg.getId();
+   frame.can_id = msg.getId();
 
-	if (msg.isExtended()) {
-		frame.can_id |= CAN_EFF_FLAG;
-	}
+   if (msg.isExtended()) {
+      frame.can_id |= CAN_EFF_FLAG;
+   }
 
-	if (msg.isRTR()) {
-		frame.can_id |= CAN_RTR_FLAG;
-	}
+   if (msg.isRTR()) {
+      frame.can_id |= CAN_RTR_FLAG;
+   }
 
-	if (msg.isErrorFrame()) {
-		frame.can_id |= CAN_ERR_FLAG;
-	}
+   if (msg.isErrorFrame()) {
+      frame.can_id |= CAN_ERR_FLAG;
+   }
 
-	uint8_t len = msg.getLength();
-	if (len>8) { len = 8; }
+   uint8_t len = msg.getLength();
+   if (len>8) { len = 8; }
 
-	frame.can_dlc = len;
-	for (int i=0; i<len; i++) {
-		frame.data[i] = msg.getByte(i);
-	}
+   frame.can_dlc = len;
+   for (int i=0; i<len; i++) {
+      frame.data[i] = msg.getByte(i);
+   }
 
-	::write(_fd, &frame, sizeof(struct can_frame));
+   ::write(_fd, &frame, sizeof(struct can_frame));
 }
 
 bool SocketCanInterface::readMessage(CanMessage &msg, unsigned int timeout_ms) {
@@ -450,7 +450,7 @@ bool SocketCanInterface::readMessage(CanMessage &msg, unsigned int timeout_ms) {
         msg.setExtended((frame.can_id & CAN_EFF_FLAG)!=0);
         msg.setRTR((frame.can_id & CAN_RTR_FLAG)!=0);
         msg.setErrorFrame((frame.can_id & CAN_ERR_FLAG)!=0);
-        msg.setInterfaceId(getId());
+        msg.setInterfaceId(0);
 
         uint8_t len = frame.can_dlc;
         if (len>8) { len = 8; }

--- a/src/driver/SocketCanDriver/SocketCanInterface.h
+++ b/src/driver/SocketCanDriver/SocketCanInterface.h
@@ -93,8 +93,8 @@ public:
 private:
     typedef enum {
         ts_mode_SIOCSHWTSTAMP,
-        ts_mode_SIOCGSTAMP_OLD,
-        ts_mode_SIOCSARP
+        ts_mode_SIOCGSTAMPNS,
+        ts_mode_SIOCGSTAMP
     } ts_mode_t;
 
     int _idx;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -431,9 +431,9 @@ void MainWindow::showAboutDialog()
        "cangaroo\n"
        "open source can bus analyzer\n"
        "\n"
-       "version 0.2.3\n"
+       "version 0.2.4\n"
        "\n"
-       "(c)2015-2017 Hubert Denkmair"
+       "(c)2015-2017 Hubert Denkmair\n"
        "(c)2018 Ethan Zonca"
     );
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -67,6 +67,7 @@ public slots:
     void startMeasurement();
     void stopMeasurement();
     void saveTraceToFile();
+    void loadTraceFromFile();
 
     void updateMeasurementActions();
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -69,7 +69,7 @@
      <x>0</x>
      <y>0</y>
      <width>1200</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -123,6 +123,7 @@
     <addaction name="action_TraceClear"/>
     <addaction name="separator"/>
     <addaction name="actionSave_Trace_to_file"/>
+    <addaction name="action_Load_Trace_from_file"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuMeasurement"/>
@@ -255,6 +256,16 @@
   <action name="actionTransmit_View">
    <property name="text">
     <string>Transmit View</string>
+   </property>
+  </action>
+  <action name="actionLoad_Capture_File">
+   <property name="text">
+    <string>&amp;Load Capture File...</string>
+   </property>
+  </action>
+  <action name="action_Load_Trace_from_file">
+   <property name="text">
+    <string>&amp;Load Trace from file...</string>
    </property>
   </action>
  </widget>

--- a/src/src.pro
+++ b/src/src.pro
@@ -18,9 +18,10 @@ unix:OBJECTS_DIR = ../build/o/unix
 win32:OBJECTS_DIR = ../build/o/win32
 macx:OBJECTS_DIR = ../build/o/mac
 
+INCLUDEPATH += $$PWD/LightPcapNg/include
 
 SOURCES += main.cpp\
-    mainwindow.cpp \
+    mainwindow.cpp
 
 HEADERS  += mainwindow.h \
 
@@ -37,6 +38,7 @@ include($$PWD/window/LogWindow/LogWindow.pri)
 include($$PWD/window/GraphWindow/GraphWindow.pri)
 include($$PWD/window/CanStatusWindow/CanStatusWindow.pri)
 include($$PWD/window/RawTxWindow/RawTxWindow.pri)
+include($$PWD/LightPcapNg.pri)
 
 unix:PKGCONFIG += libnl-3.0
 unix:PKGCONFIG += libnl-route-3.0

--- a/src/window/RawTxWindow/RawTxWindow.ui
+++ b/src/window/RawTxWindow/RawTxWindow.ui
@@ -28,10 +28,10 @@
   <widget class="QPushButton" name="singleSendButton">
    <property name="geometry">
     <rect>
-     <x>270</x>
-     <y>120</y>
-     <width>91</width>
-     <height>23</height>
+     <x>10</x>
+     <y>100</y>
+     <width>87</width>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -41,10 +41,10 @@
   <widget class="QPushButton" name="repeatSendButton">
    <property name="geometry">
     <rect>
-     <x>10</x>
-     <y>120</y>
-     <width>71</width>
-     <height>23</height>
+     <x>110</x>
+     <y>100</y>
+     <width>95</width>
+     <height>25</height>
     </rect>
    </property>
    <property name="text">
@@ -57,30 +57,14 @@
   <widget class="QLabel" name="label_11">
    <property name="geometry">
     <rect>
-     <x>150</x>
-     <y>120</y>
-     <width>21</width>
-     <height>20</height>
+     <x>300</x>
+     <y>100</y>
+     <width>31</width>
+     <height>26</height>
     </rect>
    </property>
    <property name="text">
     <string>ms</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_12">
-   <property name="geometry">
-    <rect>
-     <x>180</x>
-     <y>120</y>
-     <width>91</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>All values are hex</string>
-   </property>
-   <property name="textFormat">
-    <enum>Qt::PlainText</enum>
    </property>
   </widget>
   <widget class="QLineEdit" name="fieldAddress">
@@ -104,8 +88,8 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>39</width>
-     <height>13</height>
+     <width>55</width>
+     <height>17</height>
     </rect>
    </property>
    <property name="text">
@@ -136,8 +120,8 @@
     <rect>
      <x>90</x>
      <y>10</y>
-     <width>19</width>
-     <height>13</height>
+     <width>28</width>
+     <height>17</height>
     </rect>
    </property>
    <property name="text">
@@ -443,10 +427,10 @@
   <widget class="QSpinBox" name="spinBox_RepeatRate">
    <property name="geometry">
     <rect>
-     <x>91</x>
-     <y>120</y>
-     <width>51</width>
-     <height>22</height>
+     <x>220</x>
+     <y>100</y>
+     <width>74</width>
+     <height>26</height>
     </rect>
    </property>
    <property name="maximum">
@@ -459,10 +443,10 @@
   <widget class="QCheckBox" name="checkBox_IsRTR">
    <property name="geometry">
     <rect>
-     <x>220</x>
+     <x>140</x>
      <y>70</y>
-     <width>41</width>
-     <height>17</height>
+     <width>54</width>
+     <height>23</height>
     </rect>
    </property>
    <property name="text">
@@ -474,8 +458,8 @@
     <rect>
      <x>10</x>
      <y>70</y>
-     <width>91</width>
-     <height>17</height>
+     <width>109</width>
+     <height>23</height>
     </rect>
    </property>
    <property name="text">
@@ -485,10 +469,10 @@
   <widget class="QCheckBox" name="checkBox_IsErrorFrame">
    <property name="geometry">
     <rect>
-     <x>270</x>
+     <x>230</x>
      <y>70</y>
-     <width>81</width>
-     <height>17</height>
+     <width>106</width>
+     <height>23</height>
     </rect>
    </property>
    <property name="text">


### PR DESCRIPTION
Your recent changes didn't build on my system with a 4.15.0 kernel.  

I did some research and found https://wiki.gentoo.org/wiki/Linux_headers_5.2_porting_notes/SIOCGSTAMP which claims a header include is the only change needed so I reverted the other changes.  In particular I couldn't make sense of commit 326df709d3eb11e1611bf268810925ef453691b1 "changed SIOCGSTAMP to SIOCSARP".

Please let me know what you think and if you are interested in pull requests or not.  The original repository (https://github.com/HubertD/cangaroo) hasn't been touched in 5 years.

Skip